### PR TITLE
Add globals

### DIFF
--- a/apps/cms/src/fields/link.ts
+++ b/apps/cms/src/fields/link.ts
@@ -1,0 +1,157 @@
+import type { Field, GroupField } from 'payload/types'
+
+import deepMerge from '../utilities/deepMerge'
+
+export const appearanceOptions = {
+  primary: {
+    label: 'Primary Button',
+    value: 'primary',
+  },
+  secondary: {
+    label: 'Secondary Button',
+    value: 'secondary',
+  },
+  default: {
+    label: 'Default',
+    value: 'default',
+  },
+}
+
+export type LinkAppearances = 'primary' | 'secondary' | 'default'
+
+type LinkType = (options?: {
+  appearances?: LinkAppearances[] | false
+  disableLabel?: boolean
+  overrides?: Partial<GroupField>
+}) => Field
+
+const link: LinkType = ({
+  appearances,
+  disableLabel = false,
+  overrides = {},
+} = {}) => {
+  let linkResult: Field = {
+    name: 'link',
+    type: 'group',
+    admin: {
+      hideGutter: true,
+      ...(overrides?.admin || {}),
+    },
+    fields: [
+      {
+        type: 'row',
+        fields: [
+          {
+            name: 'type',
+            type: 'radio',
+            options: [
+              {
+                label: 'Internal link',
+                value: 'reference',
+              },
+              {
+                label: 'Custom URL',
+                value: 'custom',
+              },
+            ],
+            defaultValue: 'reference',
+            admin: {
+              layout: 'horizontal',
+              width: '50%',
+            },
+          },
+          {
+            name: 'newTab',
+            label: 'Open in new tab',
+            type: 'checkbox',
+            admin: {
+              width: '50%',
+              style: {
+                alignSelf: 'flex-end',
+              },
+            },
+          },
+        ],
+      },
+    ],
+  }
+
+  let linkTypes: Field[] = [
+    {
+      name: 'reference',
+      label: 'Document to link to',
+      type: 'relationship',
+      relationTo: ['pages'],
+      required: true,
+      maxDepth: 1,
+      admin: {
+        condition: (_, siblingData) => siblingData?.type === 'reference',
+      },
+    },
+    {
+      name: 'url',
+      label: 'Custom URL',
+      type: 'text',
+      required: true,
+      admin: {
+        condition: (_, siblingData) => siblingData?.type === 'custom',
+      },
+    },
+  ]
+
+  if (!disableLabel) {
+    linkTypes.map((linkType) => ({
+      ...linkType,
+      admin: {
+        ...linkType.admin,
+        width: '50%',
+      },
+    }))
+
+    linkResult.fields.push({
+      type: 'row',
+      fields: [
+        ...linkTypes,
+        {
+          name: 'label',
+          label: 'Label',
+          type: 'text',
+          required: true,
+          admin: {
+            width: '50%',
+          },
+        },
+      ],
+    })
+  } else {
+    linkResult.fields = [...linkResult.fields, ...linkTypes]
+  }
+
+  if (appearances !== false) {
+    let appearanceOptionsToUse = [
+      appearanceOptions.default,
+      appearanceOptions.primary,
+      appearanceOptions.secondary,
+    ]
+
+    if (appearances) {
+      appearanceOptionsToUse = appearances.map(
+        (appearance) => appearanceOptions[appearance],
+      )
+    }
+
+    linkResult.fields.push({
+      name: 'appearance',
+      type: 'select',
+      defaultValue: 'default',
+      options: appearanceOptionsToUse,
+      admin: {
+        description: 'Choose how the link should be rendered.',
+      },
+    })
+  }
+
+  return deepMerge(linkResult, overrides)
+}
+
+export default link

--- a/apps/cms/src/globals/Footer.ts
+++ b/apps/cms/src/globals/Footer.ts
@@ -1,0 +1,38 @@
+import type { GlobalConfig } from 'payload/types'
+
+import link from '../fields/link'
+
+export const Footer: GlobalConfig = {
+  slug: 'footer',
+  access: {
+    read: () => true,
+  },
+  fields: [
+    {
+      name: 'navColumns',
+      type: 'array',
+      minRows: 1,
+      maxRows: 3,
+      fields: [
+        {
+          name: 'label',
+          type: 'text',
+          required: true,
+        },
+        {
+          name: 'navItems',
+          type: 'array',
+          minRows: 1,
+          fields: [
+            link({
+              overrides: {
+                label: false,
+              },
+              appearances: false,
+            }),
+          ],
+        },
+      ],
+    },
+  ],
+}

--- a/apps/cms/src/globals/MainMenu.ts
+++ b/apps/cms/src/globals/MainMenu.ts
@@ -1,0 +1,71 @@
+import type { GlobalConfig } from 'payload/types'
+
+import link from '../fields/link'
+
+export const MainMenu: GlobalConfig = {
+  slug: 'main-menu',
+  access: {
+    read: () => true,
+  },
+  fields: [
+    {
+      name: 'tabs',
+      type: 'array',
+      label: 'Main Menu Items',
+      fields: [
+        {
+          name: 'label',
+          type: 'text',
+          required: true,
+        },
+        {
+          name: 'type',
+          type: 'radio',
+          required: true,
+          options: [
+            {
+              label: 'Direct Link',
+              value: 'directLink',
+            },
+            {
+              label: 'Dropdown',
+              value: 'dropdown',
+            },
+          ],
+        },
+        {
+          label: 'Direct Link',
+          type: 'collapsible',
+          admin: {
+            condition: (_, siblingData) => siblingData.type === 'directLink',
+          },
+          fields: [
+            link({
+              appearances: false,
+              disableLabel: true,
+              overrides: {
+                label: false,
+              },
+            }),
+          ],
+        },
+        {
+          name: 'dropdownLinks',
+          type: 'array',
+          minRows: 2,
+          admin: {
+            condition: (_, siblingData) => siblingData.type === 'dropdown',
+          },
+          fields: [
+            link({
+              overrides: {
+                label: false,
+              },
+              appearances: false,
+            }),
+          ],
+        },
+      ],
+    },
+  ],
+}

--- a/apps/cms/src/payload.config.ts
+++ b/apps/cms/src/payload.config.ts
@@ -13,6 +13,9 @@ import { Posts } from './collections/Posts'
 import { ReusableContent } from './collections/ReusableContent'
 import { Users } from './collections/Users'
 
+import { Footer } from './globals/Footer'
+import { MainMenu } from './globals/MainMenu'
+
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
@@ -21,6 +24,7 @@ export default buildConfig({
     user: Users.slug,
   },
   collections: [Categories, Media, Pages, Posts, ReusableContent, Users],
+  globals: [Footer, MainMenu],
   editor: lexicalEditor({}),
   // plugins: [payloadCloud()], // TODO: Re-enable when cloud supports 3.0
   secret: process.env.PAYLOAD_SECRET || '',


### PR DESCRIPTION
Adds basic global configs for the footer and main menu.

* Inspired by common product website navigation patterns
  * Main menu contains simple links or drop down menus (with links) (e.g. [Robinhood](https://newsroom.aboutrobinhood.com/), [Retool](https://retool.com/))
  * Footer columns contains between 1 and 3 columns, with label and a list of links (e.g. [Linear](https://linear.app/), [Rive](https://rive.app/))
* Note the links field is from Payload examples, but it's pretty cool in that it handles internal/external links, link appearances (primary, secondary, text, etc), open in new tab, overrides, etc
* Look for `admin: { condition: () => ... }` to see conditional field display in action!

## Screenshots

**Admin Dashboard:**

<img width="1155" alt="image" src="https://github.com/vigetlabs/astro-payload-starter/assets/283397/66780d01-3c7a-404c-b740-c472724c0240">

**Footer Global w/ Nav Columns:**

<img width="1155" alt="image" src="https://github.com/vigetlabs/astro-payload-starter/assets/283397/a324a6cd-cbe0-43b4-9f25-a768062f3c55">

**Main Menu Global w/ Main Menu Items:**

<img width="1155" alt="image" src="https://github.com/vigetlabs/astro-payload-starter/assets/283397/7a20284c-adc8-4028-9f4b-2e05486099c2">
