### PR TITLE
CMS Generators

### DIFF
--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -11,6 +11,7 @@
     "build": "cross-env NODE_OPTIONS=--no-deprecation next build",
     "dev": "cross-env NODE_OPTIONS=--no-deprecation next dev",
     "devsafe": "rm -rf .next && cross-env NODE_OPTIONS=--no-deprecation next dev",
+    "generate:config": "turbo gen payload-config",
     "generate:types": "payload generate:types",
     "lint": "cross-env NODE_OPTIONS=--no-deprecation next lint",
     "payload": "cross-env NODE_OPTIONS=--no-deprecation payload",
@@ -31,6 +32,7 @@
     "sharp": "0.33.4"
   },
   "devDependencies": {
+    "@turbo/gen": "^1.12.4",
     "@types/node": "^20.14.2",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",

--- a/apps/cms/turbo/generators/config.ts
+++ b/apps/cms/turbo/generators/config.ts
@@ -1,0 +1,30 @@
+import type { PlopTypes } from '@turbo/gen'
+
+// Learn more about Turborepo Generators at https://turbo.build/repo/docs/core-concepts/monorepos/code-generation
+
+export default function generator(plop: PlopTypes.NodePlopAPI): void {
+  // A simple generator to add new Payload CMS configuration files
+  plop.setGenerator('payload-configuration', {
+    description: 'Adds a new configuration file for Payload CMS',
+    prompts: [
+      {
+        type: 'list',
+        name: 'type',
+        message: 'What type of configuration are you adding?',
+        choices: ['Block', 'Collection'],
+      },
+      {
+        type: 'input',
+        name: 'name',
+        message: 'What is the name of the configuration?',
+      },
+    ],
+    actions: [
+      {
+        type: 'add',
+        path: 'src/{{lowerCase type}}s/{{pascalCase name}}.ts',
+        templateFile: 'templates/{{lowerCase type}}.hbs',
+      },
+    ],
+  })
+}

--- a/apps/cms/turbo/generators/package.json
+++ b/apps/cms/turbo/generators/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/apps/cms/turbo/generators/templates/block.hbs
+++ b/apps/cms/turbo/generators/templates/block.hbs
@@ -1,0 +1,21 @@
+import type { Block } from 'payload/types'
+import { lexicalHTML } from '@payloadcms/richtext-lexical'
+
+import { blockFields } from '@/fields/blockFields'
+
+export const {{ pascalCase name }}: Block = {
+  slug: '{{ camelCase name }}',
+  fields: [
+    blockFields({
+      name: '{{ camelCase name }}Fields',
+      interfaceName: '{{ pascalCase name }}Fields',
+      fields: [
+        {
+          name: 'text',
+          type: 'richText',
+        },
+        lexicalHTML('text', { name: 'text_html' }),
+      ],
+    }),
+  ],
+}

--- a/apps/cms/turbo/generators/templates/collection.hbs
+++ b/apps/cms/turbo/generators/templates/collection.hbs
@@ -1,0 +1,22 @@
+import type { CollectionConfig } from 'payload/types'
+
+import { slugField } from '@/fields/slug'
+
+export const {{ pascalCase name }}: CollectionConfig = {
+  slug: '{{ kebabCase name }}',
+  access: {
+    read: () => true,
+  },
+  admin: {
+    defaultColumns: ['title', 'slug', 'createdAt'],
+    useAsTitle: 'title',
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+    },
+    slugField(),
+  ],
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
         specifier: 0.33.4
         version: 0.33.4
     devDependencies:
+      '@turbo/gen':
+        specifier: ^1.12.4
+        version: 1.13.4(@swc/core@1.5.7)(@types/node@20.14.2)(typescript@5.4.5)
       '@types/node':
         specifier: ^20.14.2
         version: 20.14.2


### PR DESCRIPTION
Following the component generator idea introduced in #25, I added another generator for Payload CMS configurations for blocks and collections. Running `turbo gen` now outputs the following:

<img width="800" alt="Screenshot 2024-06-18 at 10 26 15 AM" src="https://github.com/vigetlabs/astro-payload-starter/assets/283397/6af0cd3d-68da-451f-ab83-38896dad1621">

<img width="800" alt="image" src="https://github.com/vigetlabs/astro-payload-starter/assets/283397/3cc3d393-c463-4490-803d-4facfe3ebfcd">

<img width="800" alt="image" src="https://github.com/vigetlabs/astro-payload-starter/assets/283397/bbce30b3-fad5-4355-9f0a-3cfd7fcce53b">
