### PR TITLE
CMS generator update

### DIFF
--- a/apps/cms/turbo/generators/config.ts
+++ b/apps/cms/turbo/generators/config.ts
@@ -19,12 +19,38 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
         message: 'What is the name of the configuration?',
       },
     ],
-    actions: [
-      {
+    actions: (data) => {
+      const actions: any[] = []
+
+      // Add the configuration file
+      actions.push({
         type: 'add',
         path: 'src/{{lowerCase type}}s/{{pascalCase name}}.ts',
         templateFile: 'templates/{{lowerCase type}}.hbs',
-      },
-    ],
+      })
+
+      // Conditionally add collection configurations to the Payload config
+      if (data.type === 'Collection') {
+        // First import the collection configuration
+        actions.push({
+          type: 'append',
+          path: 'src/payload.config.ts',
+          pattern: /from '\.\/collections\/Users'(?<insertion>)/g,
+          template:
+            "import { {{pascalCase name}} } from './collections/{{pascalCase name}}'",
+        })
+
+        // Then add it to the collections array
+        actions.push({
+          type: 'append',
+          path: 'src/payload.config.ts',
+          pattern: /collections: \[(?<insertion>)/,
+          separator: '',
+          template: '{{pascalCase name}}, ',
+        })
+      }
+
+      return actions
+    },
   })
 }


### PR DESCRIPTION
Previously, the cms generator was only adding block|collection configs. This update extends the generator to also import those collection in the payload config, and automatically add them to the list of collections.

<img width="746" alt="image" src="https://github.com/user-attachments/assets/bb56097e-147d-4414-af0a-81983262322b">

<img width="950" alt="image" src="https://github.com/user-attachments/assets/dc0a9317-fbb0-4204-8cd8-dc2719267bc2">
